### PR TITLE
Fix setting the final_df variable to a string rather than as a pandas.Dataframe

### DIFF
--- a/BEstimate/BEstimate.py
+++ b/BEstimate/BEstimate.py
@@ -2797,7 +2797,7 @@ Off target analysis: %s"""
 				if summary_df is not None and len(summary_df.index) != 0:
 					print("Summary Data Frame was created!")
 					summary_df.to_csv(path + args["OUTPUT_FILE"] + "_summary_df.csv", index=False)
-					final_df = summary_df.copy()
+					final_df = "_summary_df.csv"
 					print("Summary Data Frame was written in %s as %s\n\n" % (
 						path, args["OUTPUT_FILE"] + "_summary_df.csv"))
 				else:


### PR DESCRIPTION
The _final_df_ variable is used as part of the input file name which is in turn used in running the off-targets search with the _x_crispranalyser.get_off_targets_ function.

The problem was that in one case the _final_df_ variable was set to a pandas.DataFrame rather than a string.